### PR TITLE
Don't use versioned plugin names in configuration

### DIFF
--- a/config/http.client.conf.example
+++ b/config/http.client.conf.example
@@ -1,3 +1,3 @@
 url = http://*
-lib = /usr/local/lib/libXrdClHttp-4.so
+lib = /usr/local/lib/libXrdClHttp.so
 enable = true


### PR DESCRIPTION
Using libXrdXxxx-4.so doesn't make sense for xrootd 5.
