### PR TITLE
Allow setting the plugin version from the cmake command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 
 # Defaults
 if( NOT XRDCLHTTP_SUBMODULE )
-  set(PLUGIN_VERSION 5)
+  if( NOT DEFINED PLUGIN_VERSION )
+    set(PLUGIN_VERSION 5)
+  endif()
 endif()
 
 # Options


### PR DESCRIPTION
cmake ... -DPLUGIN_VERSION:INTEGER=$(xrootd-config --plugin-version)

Since the same code can be compiled against both xrootd 4 and xrootd 5.
This works for xrootd-ceph, but not for xrdcl-http.
